### PR TITLE
centered the labels for all text sizes

### DIFF
--- a/fsm.js
+++ b/fsm.js
@@ -151,20 +151,21 @@ function ExportAsLaTeX() {
       latexBody +=
         "\\node[state" +
         stateOptionsStr +
-        "] (" +
-        node.id +
-        ") at (" +
-        fixed(node.x * this._scale, 2) +
-        "," +
-        fixed(-node.y * this._scale, 2) +
-        ") {$" +
+        ", label=center:{$" +
         (node.text.length == 0
           ? " "
           : node.text
               .replaceAll("\\epsilon", "\\varepsilon")
               .replaceAll("\\sqcup", "\\textvisiblespace")
               .replaceAll(" ", "~")) +
-        "$};\n";
+        "$}" +
+        "] (" +
+        node.id +
+        ") at (" +
+        fixed(node.x * this._scale, 2) +
+        "," +
+        fixed(-node.y * this._scale, 2) +
+        ") {};\n";
     }
 
     const pi = 3.141592653;


### PR DESCRIPTION
We previously had an error where long labels in nodes were not centered. I changed our text from being the value (?) of the node to being a literal label