### PR TITLE
Fix for Slashes not working properly #51

### DIFF
--- a/fsm.js
+++ b/fsm.js
@@ -155,10 +155,12 @@ function ExportAsLaTeX() {
         (node.text.length == 0
           ? " "
           : node.text
-              .replaceAll("\\epsilon", "\\varepsilon")
-              .replaceAll("\\blank", "\\textvisiblespace")
+              .replaceAll("\\", "\uFFFF")
+              .replaceAll("\uFFFFepsilon", "\\varepsilon")
+              .replaceAll("\uFFFFblank", "\\textvisiblespace")
               .replaceAll("$", "\\$")
               .replaceAll("#", "\\#")
+              .replaceAll("\uFFFF", "\\\\")
               .replaceAll(" ", "~")) +
         "$}" +
         "] (" +


### PR DESCRIPTION
- enter just "" into a node and the LaTeX wont compile 
This seems to be already fixed I could not reproduce the bug

enter "\abc" into a node and no text will show up on LaTeX in the node
This is fixed for any slash entry as far as I can tell, need to probably test more symbols to confirm so don't approve without checking

I used a placeholder character to make the changes so it should just work out of box but unsure(I only tested 2 cases)